### PR TITLE
Use release-patch package for release:patch script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "eslint": "^10.0.2",
         "eslint-plugin-jsdoc": "^63.0.0",
         "jasmine": "^6.0.0",
+        "release-patch": "^1.0.0",
         "typescript": "^6.0.2"
       }
     },
@@ -978,6 +979,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/release-patch": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/release-patch/-/release-patch-1.0.0.tgz",
+      "integrity": "sha512-reIEGt3J0eK2XF4x+YhusAXGxVHt2847iDBhbF+UGMd3JIfvxsiaMl+C1iZAjJCJShQDKJbh/mGquNm4Fy3TyA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "release-patch": "bin/release-patch.js"
+      }
+    },
     "node_modules/reserved-identifiers": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/reserved-identifiers/-/reserved-identifiers-1.2.0.tgz",
@@ -1795,6 +1806,12 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true
+    },
+    "release-patch": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/release-patch/-/release-patch-1.0.0.tgz",
+      "integrity": "sha512-reIEGt3J0eK2XF4x+YhusAXGxVHt2847iDBhbF+UGMd3JIfvxsiaMl+C1iZAjJCJShQDKJbh/mGquNm4Fy3TyA==",
       "dev": true
     },
     "reserved-identifiers": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "lint": "eslint \"src/**/*.js\"",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "build": "tsc -p tsconfig.json",
-    "release:patch": "npm run build && npm version patch && git push --follow-tags origin HEAD && npm publish",
+    "release:patch": "release-patch",
     "test": "jasmine"
   },
   "repository": {
@@ -36,6 +36,7 @@
     "eslint": "^10.0.2",
     "eslint-plugin-jsdoc": "^63.0.0",
     "jasmine": "^6.0.0",
+    "release-patch": "^1.0.0",
     "typescript": "^6.0.2"
   },
   "description": "Return unique items from an array, with optional projection for comparisons."


### PR DESCRIPTION
## Summary

Replaces the inline `release:patch` command with the new reusable [`release-patch`](https://github.com/kaspernj/release-patch) CLI ([npm](https://www.npmjs.com/package/release-patch)), so the release flow is shared rather than duplicated per-repo.

```diff
-    "release:patch": "npm run build && npm version patch && git push --follow-tags origin HEAD && npm publish",
+    "release:patch": "release-patch",
```

`release-patch` runs the same steps this project needs:

1. Logs in to npm if not authenticated
2. Syncs `master` with `origin/master`
3. Runs `npm run build` (uniqunize defines a `build` script, so it builds before publish)
4. Bumps the patch version without creating a git tag
5. `npm install` to refresh the lockfile
6. Commits `package.json` + `package-lock.json`
7. Pushes to `origin master`
8. `npm publish`

Adds `release-patch` as a devDependency.

## Test plan

- `release-patch` bin resolves via `node_modules/.bin/release-patch`
- `npm audit` reports 0 vulnerabilities
- Not executed locally (it performs a real release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)